### PR TITLE
Adding support for SDF version 5

### DIFF
--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/Ad.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/Ad.py
@@ -1,0 +1,96 @@
+###########################################################################
+#
+#  Copyright 2020 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+# Ad SDF Schema for API version 5
+SDF_Ad_Schema = [{
+    "type": "STRING",
+    "name": "Ad_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Ad_Group_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Name",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Display_URL",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Landing_Page_URL",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "DCM_Tracking_Placement_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "DCM_Tracking_Ad_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "DCM_Tracking_Creative_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Click_Tracker_URL",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "In_stream_Custom_Parameters",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Action_Button_Label",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Action_Headline",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Discovery_Video_Thumbnail",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Discovery_Headline",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Discovery_Description_1",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Discovery_Description_2",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Discovery_Landing_Page",
+    "mode": "NULLABLE"
+}]

--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/AdGroup.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/AdGroup.py
@@ -1,0 +1,140 @@
+###########################################################################
+#
+#  Copyright 2020 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+# Ad Group SDF Schema for API version 5
+SDF_AdGroup_Schema = [{
+    "type": "STRING",
+    "name": "Ad_Group_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Line_Item_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Name",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Ad_Format",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Cost",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Popular_Videos_Bid_Adjustment",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_YouTube_Channels_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_YouTube_Channels_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_YouTube_Videos_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_YouTube_Videos_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_URLs_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_URLs_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_Apps_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_Apps_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_App_Collections_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Placement_Targeting_App_Collections_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Gender",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Age",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Household_Income",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Parental_Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Custom_List_Targeting",
+    "mode": "NULLABLE"
+}]

--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/Campaign.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/Campaign.py
@@ -1,0 +1,176 @@
+###########################################################################
+#
+#  Copyright 2020 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+# Campaign SDF Schema for API version 5
+SDF_Campaign_Schema = [{
+    "type": "STRING",
+    "name": "Campaign_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Advertiser_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Name",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Timestamp",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Goal",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Goal_KPI",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Goal_KPI_Value",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Creative_Types",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Budget",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Start_Date",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_End_Date",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Enabled",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Exposures",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Period",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Gender",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Age",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Household_Income",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Parental_Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Digital_Content_Labels_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Sensitivity_Setting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Custom_Settings",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Services",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Labels",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Viewability_Targeting_Active_View",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Display_On_Screen",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Video_On_Screen",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Display_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Video_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Authorized_Seller_Options",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Target_New_Exchanges",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Environment_Targeting",
+    "mode": "NULLABLE"
+}]

--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/InsertionOrder.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/InsertionOrder.py
@@ -1,0 +1,340 @@
+###########################################################################
+#
+#  Copyright 2020 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+# Insertion Order SDF Schema for API version 5
+SDF_InsertionOrder_Schema = [{
+    "type": "STRING",
+    "name": "Io_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Campaign_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Name",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Timestamp",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Io_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Fees",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Integration_Code",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Details",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing_Rate",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Enabled",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Exposures",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Period",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Performance_Goal_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Performance_Goal_Value",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Measure_DAR",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Measure_DAR_Channel",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Budget_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Budget_Segments",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Auto_Budget_Allocation",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Device_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Device_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Browser_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Browser_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Digital_Content_Labels_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Sensitivity_Setting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Custom_Settings",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Services",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Labels",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Channel_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Channel_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Site_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Site_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Collection_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Collection_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_List_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Similar_Audiences",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Custom_List_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Authorized_Seller_Options",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Target_New_Exchanges",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Daypart_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Daypart_Targeting_Time_Zone",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Environment_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Viewability_Targeting_Active_View",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Display_On_Screen",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Video_On_Screen",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Display_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Video_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Audio_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Player_Size_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Gender",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Age",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Household_Income",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Parental_Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Connection_Speed_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Carrier_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Carrier_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Insertion_Order_Optimization",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Unit",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Do_Not_Exceed",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Apply_Floor_Price_For_Deals",
+    "mode": "NULLABLE"
+}]

--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/LineItem.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/LineItem.py
@@ -1,0 +1,444 @@
+###########################################################################
+#
+#  Copyright 2020 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+# Line Item SDF Schema for API version 5
+SDF_LineItem_Schema = [{
+    "type": "STRING",
+    "name": "Line_Item_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Io_Id",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Subtype",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Name",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Timestamp",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Start_Date",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "End_Date",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Budget_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Budget_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing_Rate",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Pacing_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Enabled",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Exposures",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Period",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Frequency_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_View_Frequency_Enabled",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_View_Frequency_Exposures",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_View_Frequency_Period",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Partner_Revenue_Model",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Partner_Revenue_Amount",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Conversion_Counting_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Conversion_Counting_Pct",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Conversion_Floodlight_Activity_Ids",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Fees",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Integration_Code",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Details",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Value",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Unit",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Strategy_Do_Not_Exceed",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Apply_Floor_Price_For_Deals",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Creative_Assignments",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Regional_Location_List_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Geography_Regional_Location_List_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Language_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Device_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Device_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Browser_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Browser_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Digital_Content_Labels_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Sensitivity_Setting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Brand_Safety_Custom_Settings",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Services",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Third_Party_Verification_Labels",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Channel_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Channel_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Site_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Site_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Collection_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "App_Collection_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Category_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Keyword_List_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Similar_Audiences",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Audience_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Affinity_And_In_Market_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Custom_List_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Authorized_Seller_Options",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Inventory_Source_Targeting_Target_New_Exchanges",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Daypart_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Daypart_Targeting_Time_Zone",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Environment_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Viewability_Targeting_Active_View",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_On_Screen",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Display_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Video_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Position_Targeting_Audio_Position_In_Content",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Video_Player_Size_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Gender",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Age",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Household_Income",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Demographic_Targeting_Parental_Status",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Connection_Speed_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Carrier_Targeting_Include",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Carrier_Targeting_Exclude",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "Bid_Multipliers",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Video_Ad_Formats",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Bid_Strategy_Type",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Bid_Strategy_Value",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Mobile_Bid_Adjustment_Option",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Mobile_Bid_Adjustment_Percentage",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Desktop_Bid_Adjustment_Option",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Desktop_Bid_Adjustment_Percentage",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Tablet_Bid_Adjustment_Option",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Tablet_Bid_Adjustment_Percentage",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Connected_TV_Bid_Adjustment_Option",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Connected_TV_Bid_Adjustment_Percentage",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Category_Exclusions_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Content_Filter",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Inventory_Source_Targeting",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Third_Party_Viewability_Vendor",
+    "mode": "NULLABLE"
+}, {
+    "type": "STRING",
+    "name": "TrueView_Third_Party_Brand_Safety_Vendor",
+    "mode": "NULLABLE"
+}]

--- a/orchestra/google/marketing_platform/utils/schema/sdf/v5/__init__.py
+++ b/orchestra/google/marketing_platform/utils/schema/sdf/v5/__init__.py
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-#  Copyright 2019 Google Inc.
+#  Copyright 2020 Google Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,11 +16,19 @@
 #
 ###########################################################################
 
-from orchestra.google.marketing_platform.utils.schema.sdf.v4_2 import (
-  SDF_V4_2_SCHEMA_TYPES
-)
 from orchestra.google.marketing_platform.utils.schema.sdf.v5 import (
-  SDF_V5_SCHEMA_TYPES
+  Ad,
+  AdGroup,
+  Campaign,
+  InsertionOrder,
+  LineItem
 )
 
-SDF_VERSIONED_SCHEMA_TYPES = {'4.2':SDF_V4_2_SCHEMA_TYPES,'5':SDF_V5_SCHEMA_TYPES}
+
+SDF_V5_SCHEMA_TYPES = {
+    'LINE_ITEM': LineItem.SDF_LineItem_Schema,
+    'CAMPAIGN': Campaign.SDF_Campaign_Schema,
+    'AD': Ad.SDF_Ad_Schema,
+    'AD_GROUP': AdGroup.SDF_AdGroup_Schema,
+    'INSERTION_ORDER': InsertionOrder.SDF_InsertionOrder_Schema
+}


### PR DESCRIPTION
Added table schemas to support SDF version 5 output. Documentation for SDF v5 can be found here:

https://developers.google.com/bid-manager/guides/structured-data-file/v5/LineItem